### PR TITLE
Fix issue #2 - use a smaller regexp to check for Google

### DIFF
--- a/firefox/lib/background.js
+++ b/firefox/lib/background.js
@@ -72,7 +72,7 @@ function init_variables(options) {
 
 function load_events() {
   pageMod.PageMod({
-    include: [/.*www\.google.*/],
+    include: [/\/\/www\.google/],
     contentScriptWhen: "ready",
     contentStyleFile: [
       self.data.url("stylesheets/google_serp.css"),


### PR DESCRIPTION
.\* will match the entire string. That's not necessary; we can just check for "www.google" somewhere in the string. Note also that the previous version would match, say:

http://www.bing.com/search?q=www.google

I've fixed this by anchoring to '//' before the 'www'.
